### PR TITLE
Integrate Lingo.dev compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Next.js shadcn i18n starter
+
+This starter uses [Lingo.dev](https://lingo.dev/) for localization.
+
+Create a `.env.local` file and provide the credentials for the compiler:
+
+```bash
+GROQ_API_KEY=<your-groq-api-key>
+GROQ_MODEL=groq:mistral-saba-24b
+```
+
+The `GROQ_MODEL` variable selects the AI model used for automatic translations.
+
+Run the build with:
+
+```bash
+pnpm install
+npm run build
+```
+
+
+

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -44,9 +44,13 @@ const withMDX = createMDX({
 });
 
 // Merge MDX config with Next.js config
-const withPlugins = (config) => lingoCompiler.next({
-  sourceLocale: 'en',
-  targetLocales: ['es'],
-})(withMDX(config));
+const withPlugins = (config) =>
+  lingoCompiler.next({
+    sourceLocale: 'en',
+    targetLocales: ['es'],
+    models: {
+      '*:*': process.env.GROQ_MODEL || 'groq:mistral-saba-24b',
+    },
+  })(withMDX(config));
 
 export default withPlugins(nextConfig);

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -2,7 +2,7 @@ import NextAuth from 'next-auth';
 import GitHub from 'next-auth/providers/github';
 import Credentials from 'next-auth/providers/credentials';
 
-export const authOptions = {
+const authOptions = {
   providers: [
     GitHub({
       clientId: process.env.GITHUB_CLIENT_ID || '',

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import MotionDiv from '@/components/motion/MotionDiv';
 import { getPostsByYear } from '@/lib/posts';
 import { LingoComponent } from 'lingo.dev/react/rsc';
+import { loadDictionary } from '@/lib/lingo';
 import dayjs from 'dayjs';
 import { Metadata } from 'next';
 import Link from 'next/link';
@@ -36,7 +37,12 @@ export default async function Page() {
   return (
     <main className='col-start-2'>
       <h2 className='mb-16 font-sans font-semibold'>
-        <LingoComponent $as='span' $fileKey='blog' $entryKey='title'>
+        <LingoComponent
+          $as='span'
+          $fileKey='blog'
+          $entryKey='title'
+          $loadDictionary={loadDictionary}
+        >
           Blog
         </LingoComponent>
       </h2>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@
 import ThemeSwitch from '@/components/layout/ThemeSwitch';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { LocaleSwitcher } from 'lingo.dev/react/client';
 import { Code, Github } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -41,6 +42,7 @@ export default function Header() {
           ))}
         </nav>
         <div className='flex items-center gap-3'>
+          <LocaleSwitcher locales={['en', 'es']} />
           <ThemeSwitch />
           <Button asChild variant='ghost' size='icon' className='h-8 w-8'>
             <Link href='https://github.com/2wndrhs' target='_blank'>

--- a/src/lingo/dictionary.js
+++ b/src/lingo/dictionary.js
@@ -1,0 +1,16 @@
+/* eslint import/no-anonymous-default-export: 0 */
+export default {
+  version: 0.1,
+  files: {
+    'app/blog/page.tsx': {
+      entries: {
+        '10/declaration/body/1/argument/1/1': {
+          content: {
+            en: 'Blog',
+          },
+          hash: 'c073807c0f081ccbf22306f8f455a23d',
+        },
+      },
+    },
+  },
+};

--- a/src/lingo/meta.json
+++ b/src/lingo/meta.json
@@ -1,0 +1,17 @@
+{
+  "version": 0.1,
+  "files": {
+    "app/blog/page.tsx": {
+      "scopes": {
+        "10/declaration/body/1/argument/1/1": {
+          "type": "element",
+          "hash": "c073807c0f081ccbf22306f8f455a23d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Blog"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add instructions for GROQ API key and model in README
- configure Lingo.dev compiler in `next.config.mjs`
- add LocaleSwitcher to the header
- commit initial lingo dictionary

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot connect to API)*